### PR TITLE
Make Luhn checks optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ $validator->isVisa('4242424242424242');
 $typeConfig = $validator->getType('4242424242424242');
 ```
 
+### Get the type configuration of a card number, but do not do a Luhn check
+#### Why do this?
+If you are wanting a way to get the brand but not have this library do any validation, you can have it only pass back what brand it thinks it is. Useful for IXOPAY (TokenEx) tokens: https://documentation.ixopay.com/docs/tokenex/universal-token-schemes#sixantokenfour 
+
+```php
+$typeConfig = $validator->getTypeWithoutLuhn('424242HU0OIW4242');
+```
+
 With the type configuration you can know metadata info, perform some validation 
 or format the card number using the class methods.
 

--- a/src/CreditCardTypeConfig.php
+++ b/src/CreditCardTypeConfig.php
@@ -239,6 +239,17 @@ class CreditCardTypeConfig
     }
 
     /**
+     * Checks if the given card number matches this card type configuration, but skips luhn checks
+     * 
+     * @param string|int $cardNumber
+     * @return bool
+     */
+    public function matchesWithoutLuhn($cardNumber)
+    {
+        return $this->matchesLengths($cardNumber) && $this->matchesPatterns($cardNumber);
+    }
+
+    /**
      * Checks if the card number matches one of the patterns array configuration.
      *
      * @param string|int $cardNumber

--- a/src/CreditCardValidator.php
+++ b/src/CreditCardValidator.php
@@ -163,6 +163,30 @@ class CreditCardValidator
     }
 
     /**
+     * Gets the best CreditCardTypeConfig object that matches the given card number.
+     * 
+     * @param string|int $cardNumber
+     * @return CreditCardTypeConfig|null
+     */
+    public function getTypeWithoutLuhn($cardNumber)
+    {
+        $candidate = null;
+        $candidateStrength = 0;
+
+        foreach ($this->getTypesInfo() as $config) {
+            if ($config->matchesWithoutLuhn($cardNumber)) {
+                $strength = $config->getMatchingPatternStrength($cardNumber);
+                if ($strength > $candidateStrength) {
+                    $candidate = $config;
+                    $candidateStrength = $strength;
+                }
+            }
+        }
+
+        return $candidate;
+    }
+
+    /**
      * Checks if the credit card number is valid.
      * 
      * @param string $cardNumber

--- a/tests/CreditCardValidatorTest.php
+++ b/tests/CreditCardValidatorTest.php
@@ -247,6 +247,58 @@ class CreditCardValidatorTest extends MockeryTestCase
     /**
      * @group CreditCardValidatorTest
      */
+    public function testGetTypeWithoutLuhnReturnVisaCreditCardTypeConfigObjectForAVisaCardNumber()
+    {
+        $validator = CreditCardValidator::make();
+
+        $result = $validator->getTypeWithoutLuhn('424242xxxxxx4242');
+
+        $this->assertInstanceOf(CreditCardTypeConfig::class, $result);
+        $this->assertEquals(CreditCardValidator::TYPE_VISA, $result->getType());
+    }
+
+    /**
+     * @group CreditCardValidatorTest
+     */
+    public function testGetTypeWithoutLuhnReturnMastercardCreditCardTypeConfigObjectForAMastercardCardNumber()
+    {
+        $validator = CreditCardValidator::make();
+
+        $result = $validator->getTypeWithoutLuhn('555555xxxxxx4444');
+
+        $this->assertInstanceOf(CreditCardTypeConfig::class, $result);
+        $this->assertEquals(CreditCardValidator::TYPE_MASTERCARD, $result->getType());
+    }
+
+    /**
+     * @group CreditCardValidatorTest
+     */
+    public function testGetTypeWithoutLuhnReturnAmericanExpressCreditCardTypeConfigObjectForAnAmericanExpressCardNumber()
+    {
+        $validator = CreditCardValidator::make();
+
+        $result = $validator->getTypeWithoutLuhn('378282xxxxx0005');
+
+        $this->assertInstanceOf(CreditCardTypeConfig::class, $result);
+        $this->assertEquals(CreditCardValidator::TYPE_AMERICAN_EXPRESS, $result->getType());
+    }
+
+    /**
+     * @group CreditCardValidatorTest
+     */
+    public function testGetTypeWithoutLuhnReturnDiscoverCreditCardTypeConfigObjectForADiscoverCardNumber()
+    {
+        $validator = CreditCardValidator::make();
+
+        $result = $validator->getTypeWithoutLuhn('601111xxxxxx1117');
+
+        $this->assertInstanceOf(CreditCardTypeConfig::class, $result);
+        $this->assertEquals(CreditCardValidator::TYPE_DISCOVER, $result->getType());
+    }
+
+    /**
+     * @group CreditCardValidatorTest
+     */
     public function testGetTypeReturnNullForAnInvalidCreditCardNumber()
     {
         $validator = CreditCardValidator::make();


### PR DESCRIPTION
This pull request introduces a new feature that allows the credit card validator to determine the type of a card number without performing a Luhn check. The most important changes include adding new methods to support this functionality and updating the documentation and tests accordingly.

### New Methods for Skipping Luhn Check:

* [`src/CreditCardTypeConfig.php`](diffhunk://#diff-0e7e027c9888b18dba7f5f99cc5994170aaf1c52ec77578bf7a69410dfd473adR241-R251): Added the `matchesWithoutLuhn` method to check if a card number matches the card type configuration without performing a Luhn check.
* [`src/CreditCardValidator.php`](diffhunk://#diff-8ec43f2a172ecc23aa6322d5b6e3f69c45cc9f3c0429c0b1ffe91ee5298e0d3dR165-R188): Added the `getTypeWithoutLuhn` method to get the best `CreditCardTypeConfig` object that matches a given card number without performing a Luhn check.

### Documentation Update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108-R115): Updated the documentation to include an example of how to use the new `getTypeWithoutLuhn` method and explained its use case.

### Test Cases:

* [`tests/CreditCardValidatorTest.php`](diffhunk://#diff-d6403ca9f293412abe5bffe53f59bdff7a4a0fae1fd58eac76644911d9fedecfR247-R298): Added several test cases to ensure that the `getTypeWithoutLuhn` method correctly identifies the card type for various card numbers, including Visa, Mastercard, American Express, and Discover.